### PR TITLE
test(Mix.Tasks.Ashes.Generate): tests for controller, model and channel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /deps
 erl_crash.dump
 *.ez
+/tmp

--- a/mix.exs
+++ b/mix.exs
@@ -28,7 +28,11 @@ defmodule Ashes.Mixfile do
   #
   # Type `mix help deps` for more examples and options
   defp deps do
-    [] end
+    [
+      {:phoenix, ">= 0.8.0", only: :test},
+      {:cowboy, ">= 1.0.0", only: :test}
+    ]
+  end
 
   defp package do
     [

--- a/mix.lock
+++ b/mix.lock
@@ -1,0 +1,6 @@
+%{"cowboy": {:hex, :cowboy, "1.0.0"},
+  "cowlib": {:hex, :cowlib, "1.0.1"},
+  "phoenix": {:hex, :phoenix, "0.8.0"},
+  "plug": {:hex, :plug, "0.9.0"},
+  "poison": {:hex, :poison, "1.3.0"},
+  "ranch": {:hex, :ranch, "1.0.0"}}

--- a/test/fixtures/router.ex
+++ b/test/fixtures/router.ex
@@ -1,0 +1,2 @@
+defmodule PhotoBlog.Router do
+end

--- a/test/mix/mix_helper.exs
+++ b/test/mix/mix_helper.exs
@@ -1,0 +1,21 @@
+defmodule MixHelper do
+  import ExUnit.Assertions
+
+  def tmp_path do
+    Path.expand("../../tmp", __DIR__)
+  end
+
+  def assert_file(file) do
+    assert File.regular?(file), "Expected #{file} to exist, but does not"
+  end
+
+  def assert_file(file, match) do
+    cond do
+      Regex.regex?(match) ->
+        assert_file file, &(assert &1 =~ match)
+      is_function(match, 1) ->
+        assert_file(file)
+        match.(File.read!(file))
+    end
+  end
+end

--- a/test/mix/tasks/ashes/generate_test.exs
+++ b/test/mix/tasks/ashes/generate_test.exs
@@ -1,0 +1,60 @@
+Code.require_file "../../mix_helper.exs", __DIR__
+
+defmodule Mix.Tasks.Ashes.GenerateTest do
+  use ExUnit.Case
+
+  import MixHelper
+  import ExUnit.CaptureIO
+
+  @app_name  "photo_blog"
+  @tmp_path  tmp_path()
+  @project_path Path.join(@tmp_path, @app_name)
+
+  setup_all do
+    templates_path = Path.join([@project_path, "deps", "ashes", "templates"])
+    root_path =  File.cwd!
+
+    #Clean up
+    File.rm_rf @project_path
+
+    #Create path for app
+    File.mkdir_p Path.join(@project_path, "web")
+
+    #Copy fixture router into web directory
+    File.cp! Path.join([root_path, "test", "fixtures", "router.ex"]), Path.join([@project_path, "web", "router.ex"])
+
+    #Create path for templates
+    File.mkdir_p templates_path
+
+    #Copy templates into `deps/ashes/templates` to mimic a real Phoenix application
+    File.cp_r! Path.join(root_path, "templates"), templates_path
+
+    #Move into the project directory to run the generator
+    File.cd! @project_path
+  end
+
+  test "creates controller files and directories" do
+    Mix.Tasks.Ashes.Generate.run(["controller", "user"])
+    assert_file "web/controllers/user_controller.ex"
+
+    assert File.exists?("web/templates/user")
+  end
+
+  test "creates controller files with --skip-template" do
+    Mix.Tasks.Ashes.Generate.run(["controller", "photo", "--skip-template"])
+    assert_file "web/controllers/photo_controller.ex"
+
+    refute File.exists?("web/templates/photo")
+  end
+
+  test "creates a channel file" do
+    Mix.Tasks.Ashes.Generate.run(["channel", "user"])
+    assert_file "web/channels/user_channel.ex"
+  end
+
+  test "creates model file" do
+    Mix.Tasks.Ashes.Generate.run(["model", "user"])
+    assert_file "web/models/user.ex"
+  end
+
+end


### PR DESCRIPTION
Tests have been added for the generation of controllers, models and
channels.

The tests are heavily based on:

  https://github.com/phoenixframework/phoenix/blob/3ae44468c5dfc89af61f549809e64c2f1b4ce95e/test/mix/tasks/phoenix/new_test.exs

Currently the tests do not clean up after each run. This means that the
test for creating a controller without the templates currently uses a
unique name to ensure it is not testing artifacts from a previous test.

Since ashes is intended to be used inside of a Phoenix project, the
`deps/ashes/templates` path is expected to exist. In the set up of the
tests, this folder is creates and the tests are copied manually to mimic
a real Phoenix application.